### PR TITLE
#14 issue with idekey

### DIFF
--- a/source/content.js
+++ b/source/content.js
@@ -1,98 +1,82 @@
-
-chrome.extension.onRequest.addListener(
-		function(request, sender, sendResponse)
+var xdebug = (function()
+{//create closure for idekey
+	var idekey = 'XDEBUG_ECLIPSE',
+	expose = {};
+	expose.handler = function(request, sender, sendResponse)
+	{
+		var result = {result : undefined};
+		if (request.idkey)
 		{
-			idekey = "XDEBUG_ECLIPSE";
-			if (request.idekey)
-			{
-				idekey = request.idekey;
-			}
-
-			if (request.cmd == "status")
-			{
-				result = xdebugCheckStatus();
-			}
-			else if (request.cmd == "toggle")
-			{
-				result = xdebugToggle();
-			}
-
-			sendResponse({result: result});
+			idekey = request.idekey;
 		}
-);
-
-function xdebugCheckStatus()
-{
-	if (xdebugGetCookie('XDEBUG_SESSION') == idekey)
+		if (request.cmd === 'status')
+		{
+			result.result = expose.checkStatus();
+		}
+		else if (request.cmd === 'toggle')
+		{
+			result.result = expose.toggle();
+		}
+		sendResponse(result);
+	};
+	expose.checkStatus = function()
 	{
-		return 1;
-	}
-	else if (xdebugGetCookie('XDEBUG_PROFILE') == idekey)
+		switch(idekey)
+		{
+			case expose.getCookie('XDEBUG_SESSION'):
+				return 1;
+			case expose.getCookie('XDEBUG_PROFILE'):
+				return 2;
+			case expose.getCookie('XDEBUG_TRACE'):
+				return 3;
+		}
+		return 0;
+	};
+	expose.toggle = function()
 	{
-		return 2;
-	}
-	else if (xdebugGetCookie('XDEBUG_TRACE') == idekey)
+		var debuggingState = expose.checkStatus();
+		switch (expose.checkStatus())
+		{
+			case 0:
+				expose.setCookie('XDEBUG_SESSION', idekey, 60);
+				expose.setCookie('XDEBUG_PROFILE', null, -60);
+				expose.setCookie('XDEBUG_TRACE', null, -60);
+			break;
+			case 1:
+				expose.setCookie('XDEBUG_SESSION', null, -60);
+				expose.setCookie('XDEBUG_PROFILE', idekey, 60);
+				expose.setCookie('XDEBUG_TRACE', null, -60);
+			break;
+			case 2:
+				expose.setCookie('XDEBUG_SESSION', null, -60);
+				expose.setCookie('XDEBUG_PROFILE', null, -60);
+				expose.setCookie('XDEBUG_TRACE', idekey, 60);
+			break;
+			case 3:
+				expose.setCookie('XDEBUG_SESSION', null, -60);
+				expose.setCookie('XDEBUG_PROFILE', null, -60);
+				expose.setCookie('XDEBUG_TRACE', null, -60);
+		}
+		return expose.checkStatus();
+	};
+	expose.setCookie = function (cookieName, cookieVal, minutes)
 	{
-		return 3;
-	}
-
-	return 0;
-}
-
-function xdebugToggle()
-{
-	var debuggingState = xdebugCheckStatus();
-
-	if (debuggingState == 0)
+		var exp = new Date();
+		exp.setTime(exp.getTime() + ((minutes || 0) * 60000));
+		document.cookie = cookieName + "=" + cookieVal + "; expires=" + exp.toGMTString() + "; path=/";
+	};
+	expose.getCookie = function(name)
 	{
-		// Current is all off, switch debugging on
-		xdebugSetCookie('XDEBUG_SESSION', idekey, 60);
-		xdebugSetCookie('XDEBUG_PROFILE', null, -60);
-		xdebugSetCookie('XDEBUG_TRACE', null, -60);
-	}
-	else if (debuggingState == 1)
-	{
-		// Current is debugging on; switch debugging off and profiling on
-		xdebugSetCookie('XDEBUG_SESSION', null, -60);
-		xdebugSetCookie('XDEBUG_PROFILE', idekey, 60);
-		xdebugSetCookie('XDEBUG_TRACE', null, -60);
-	}
-	else if (debuggingState == 2)
-	{
-		// Current is profiling on; switch profiling off and tracing on
-		xdebugSetCookie('XDEBUG_SESSION', null, -60);
-		xdebugSetCookie('XDEBUG_PROFILE', null, -60);
-		xdebugSetCookie('XDEBUG_TRACE', idekey, 60);
-	}
-	else if (debuggingState == 3)
-	{
-		// Current is tracing on; switch all off
-		xdebugSetCookie('XDEBUG_SESSION', null, -60);
-		xdebugSetCookie('XDEBUG_PROFILE', null, -60);
-		xdebugSetCookie('XDEBUG_TRACE', null, -60);
-	}
+		var prefix = name + '=';
+		var startIdx = document.cookie.indexOf(prefix);
+		if (startIdx === -1)
+		{
+			return null;
+		}
+		startIdx += name.length + 1;
+		return document.cookie.substring(startIdx).match(/^[^;]+/)[0];
+	};
+	return expose;
+}());
+chrome.extension.onRequest.addListener(xdebug.handler);
 
-	// Return the new state
-	return xdebugCheckStatus();
-}
-
-function xdebugSetCookie(cookieName, cookieVal, minutes)
-{
-	var exp = new Date();
-	exp.setTime(exp.getTime() + (minutes * 60 * 1000));
-	document.cookie = cookieName + "=" + cookieVal + "; expires=" + exp.toGMTString() + "; path=/";
-}
-
-function xdebugGetCookie(name)
-{
-	var prefix = name + "=";
-	var cookieStartIndex = document.cookie.indexOf(prefix);
-	if (cookieStartIndex == -1)
-		return null;
-
-	var cookieEndIndex = document.cookie.indexOf(";", cookieStartIndex + prefix.length);
-	if (cookieEndIndex == -1)
-		cookieEndIndex = document.cookie.length;
-
-	return unescape(document.cookie.substring(cookieStartIndex + prefix.length, cookieEndIndex));
-}


### PR DESCRIPTION
removed (implied) globals, fixed idekey undefined issue for chrome v23. I'm running forked version without issues:

The variable idekey is undefined in chrome (v23) under win7:

console.error("Error in event handler for '" + this.eventName_ +
Error in event handler for 'undefined': idekey is not defined ReferenceError: idekey is not defined
at xdebugCheckStatus (chrome-extension://[...]/content.js:25:43)
at chrome-extension://[...]/content.js:12:14
at chrome.Event.dispatchToListener (event_bindings:387:21)
at chrome.Event.dispatch_ (event_bindings:373:27)
at chrome.Event.dispatch (event_bindings:393:17)
at miscellaneous_bindings:163:26
at chrome.Event.dispatchToListener (event_bindings:387:21)
at chrome.Event.dispatch_ (event_bindings:373:27)
at chrome.Event.dispatch (event_bindings:393:17)
at Object.chromeHidden.Port.dispatchOnMessage (miscellaneous_bindings:253:22)
