### PR TITLE
FIXED: save button not working

### DIFF
--- a/source/manifest.json
+++ b/source/manifest.json
@@ -1,7 +1,7 @@
 {
 	"name": "Xdebug helper",
 	"description": "Easy debugging, profiling and tracing extension for Xdebug",
-	"version": "1.4.0",
+	"version": "1.4.1",
 
 	"manifest_version": 2,
 	"minimum_chrome_version": "20",

--- a/source/options.html
+++ b/source/options.html
@@ -36,9 +36,10 @@
 					<option value="XDEBUG_ECLIPSE">Eclipse</option>
 					<option value="netbeans-xdebug">Netbeans</option>
 					<option value="macgdbp">MacGDBp</option>
+					<option value="PHPSTORM">PhpStorm</option>
 					<option value="null">Other</option>
 				</select>
-				<span id="customkey"><input type="text" id="idekey" /> <a href="javascript:;"><img style="vertical-align: middle;" src="images/disk.png" alt="Save" title="Save" /></a></span>
+				<span id="customkey"><input type="text" id="idekey" /> <a href="#" id="save-options"><img style="vertical-align: middle;" src="images/disk.png" alt="Save" title="Save" /></a></span>
 			</p>
 
 			<h3>Domain filter</h3>

--- a/source/options.js
+++ b/source/options.js
@@ -22,7 +22,7 @@ function restore_options()
 		idekey = "XDEBUG_ECLIPSE";
 	}
 
-	if (idekey == "XDEBUG_ECLIPSE" || idekey == "netbeans-xdebug" || idekey == "macgdbp")
+	if (idekey == "XDEBUG_ECLIPSE" || idekey == "netbeans-xdebug" || idekey == "macgdbp" || idekey == "PHPSTORM")
 	{
 		$("#ide").val(idekey);
 	}
@@ -92,20 +92,13 @@ $(function()
 		}
 	});
 
-	$("#idekey").change(function()
-	{
-		save_options();
-	});
+	$("#idekey").change(save_options);
+	
+	$('#save-options').click(save_options);
 
-	$('#add-site').click(function()
-	{
-		addSite();
-	});
+	$('#add-site').click(addSite);
 
-	$('#remove-site').click(function()
-	{
-		removeSelectedSite();
-	});
+	$('#remove-site').click(removeSelectedSite);
 
 	restore_options();
 });


### PR DESCRIPTION
Fixed a bug that made it difficult to use a custom IDE key.

In options page, when choosing "Other" in the IDE `select`, the save button was not working. To save your custom IDE one had to blur (tab out or click outside) the idekey `input`.

I also added a new IDE (PhpStorm) and simplified the event-listeners (no anonymous function needed when no parameters are passed).
