### PR TITLE
switch `chrome.runtime` for `chrome.extension`

### DIFF
--- a/source/content.js
+++ b/source/content.js
@@ -139,4 +139,4 @@ var xdebug = (function() {
 })();
 
 // Attach the message listener
-chrome.extension.onMessage.addListener(xdebug.messageListener);
+chrome.runtime.onMessage.addListener(xdebug.messageListener);

--- a/source/manifest.json
+++ b/source/manifest.json
@@ -2,7 +2,7 @@
 	"name": "Xdebug helper",
 	"short_name": "XdebugHelper",
 	"description": "Easy debugging, profiling and tracing extension for Xdebug",
-	"version": "1.4.1",
+	"version": "1.4.1.1",
 	"author": "Mathijs Kadijk",
 
 	"manifest_version": 2,

--- a/source/popup.js
+++ b/source/popup.js
@@ -41,7 +41,7 @@ $(function() {
 				function(response)
 				{
 					// Make the backgroundpage update the icon and close the popup
-					chrome.extension.getBackgroundPage().updateIcon(response.status, tabs[0].id);
+					chrome.runtime.getBackgroundPage().updateIcon(response.status, tabs[0].id);
 					window.close();
 				}
 			);


### PR DESCRIPTION
So, after a little more research, I found there was an API change breaking tons of extensions. The `chrome.extension` API has been deprecated and removed in favor of the `chrome.runtime` API. Swapped those and it seems to be working now.

There are a few minor issues still:

When loading the extension, the following message is displayed:
        There were warnings when trying to install this extension:
            Unrecognized manifest key 'short_name'.

The menu is not very responsive - when a menu item is clicked, the item does not turn green. If you close and reopen the menu though it will highlight the appropriate item.

Closes #35
