### PR TITLE
trigger value support

### DIFF
--- a/source/background.js
+++ b/source/background.js
@@ -11,9 +11,9 @@ chrome.tabs.onUpdated.addListener(function(tabId, changeInfo, tab)
 	var sites = [],
 		ideKey = "XDEBUG_ECLIPSE",
 		match = true,
-		domain,
-		tracetrigger = null,
-		profiletrigger = null;
+		tt = ideKey,
+		pt = ideKey,
+		domain;
 
 	// Check if localStorage is available and get the settings out of it
 	if (localStorage)
@@ -30,12 +30,12 @@ chrome.tabs.onUpdated.addListener(function(tabId, changeInfo, tab)
 
 		if (localStorage["xdebugTraceTrigger"])
 		{
-			tracetrigger = localStorage["xdebugTraceTrigger"];
+			tt = localStorage["xdebugTraceTrigger"];
 		}
 
 		if (localStorage["xdebugProfileTrigger"])
 		{
-			profiletrigger = localStorage["xdebugTraceTrigger"];
+			pt = localStorage["xdebugProfileTrigger"];
 		}
 	}
 
@@ -54,7 +54,9 @@ chrome.tabs.onUpdated.addListener(function(tabId, changeInfo, tab)
 			tabId,
 			{
 				cmd: "getStatus",
-				idekey: ideKey
+				idekey: ideKey,
+				tt: tt,
+				pt: pt
 			},
 			function(response)
 			{
@@ -69,13 +71,23 @@ chrome.commands.onCommand.addListener(function(command)
 	if ('toggle_debug_action' == command)
 	{
 		var ideKey = "XDEBUG_ECLIPSE";
+		var tt = ideKey;
+		var pt = ideKey;
 
 		// Check if localStorage is available and get the settings out of it
 		if (localStorage && localStorage["xdebugIdeKey"])
 		{
-			ideKey 			= localStorage["xdebugIdeKey"];
-			tracetrigger 	= localStorage["xdebugTraceTrigger"];
-			profiletrigger 	= localStorage["xdebugProfileTrigger"];
+			ideKey = localStorage["xdebugIdeKey"];
+		}
+
+		if (localStorage && localStorage["xdebugTraceTrigger"])
+		{
+			tt = localStorage["xdebugTraceTrigger"];
+		}
+
+		if (localStorage && localStorage["xdebugProfileTrigger"])
+		{
+			pt = localStorage["xdebugProfileTrigger"];
 		}
 
 		// Fetch the active tab
@@ -86,7 +98,9 @@ chrome.commands.onCommand.addListener(function(command)
 				tabs[0].id,
 				{
 					cmd: "getStatus",
-					idekey: ideKey
+					idekey: ideKey,
+					tt: tt,
+					pt: pt
 				},
 				function(response)
 				{
@@ -98,7 +112,9 @@ chrome.commands.onCommand.addListener(function(command)
 						{
 							cmd: "setStatus",
 							status: newState,
-							idekey: ideKey
+							idekey: ideKey,
+							tt: tt,
+							pt: pt
 						},
 						function(response)
 						{

--- a/source/background.js
+++ b/source/background.js
@@ -60,7 +60,11 @@ chrome.tabs.onUpdated.addListener(function(tabId, changeInfo, tab)
 			},
 			function(response)
 			{
-				updateIcon(response.status, tabId);
+				if (chrome.runtime.lastError) {
+					console.log("Error: ", chrome.runtime.lastError);
+				} else {
+					updateIcon(response.status, tabId);
+				}
 			}
 		);
 	}

--- a/source/background.js
+++ b/source/background.js
@@ -11,7 +11,9 @@ chrome.tabs.onUpdated.addListener(function(tabId, changeInfo, tab)
 	var sites = [],
 		ideKey = "XDEBUG_ECLIPSE",
 		match = true,
-		domain;
+		domain,
+		tracetrigger = null,
+		profiletrigger = null;
 
 	// Check if localStorage is available and get the settings out of it
 	if (localStorage)
@@ -24,6 +26,16 @@ chrome.tabs.onUpdated.addListener(function(tabId, changeInfo, tab)
 		if (localStorage["xdebugIdeKey"])
 		{
 			ideKey = localStorage["xdebugIdeKey"];
+		}
+
+		if (localStorage["xdebugTraceTrigger"])
+		{
+			tracetrigger = localStorage["xdebugTraceTrigger"];
+		}
+
+		if (localStorage["xdebugProfileTrigger"])
+		{
+			profiletrigger = localStorage["xdebugTraceTrigger"];
 		}
 	}
 
@@ -61,7 +73,9 @@ chrome.commands.onCommand.addListener(function(command)
 		// Check if localStorage is available and get the settings out of it
 		if (localStorage && localStorage["xdebugIdeKey"])
 		{
-			ideKey = localStorage["xdebugIdeKey"];
+			ideKey 			= localStorage["xdebugIdeKey"];
+			tracetrigger 	= localStorage["xdebugTraceTrigger"];
+			profiletrigger 	= localStorage["xdebugProfileTrigger"];
 		}
 
 		// Fetch the active tab

--- a/source/content.js
+++ b/source/content.js
@@ -45,37 +45,35 @@ var xdebug = (function() {
 		{
 			var newStatus,
 				idekey = "XDEBUG_ECLIPSE",
-				tracetrigger = null,
-				profiletrigger = null;
+				tt = null,
+				pt = null;
 
 			// Use the IDE key from the request, if any is given
 			if (request.idekey)
 			{
 				idekey = request.idekey;
 			}
-			// Use the trace trigger key from the request, if any is given
-			if (request.tracetrigger)
+			if (request.tt)
 			{
-				idekey = request.tracetrigger;
+				tt = request.tt;
 			}
-			// Use the profile trigger key from the request, if any is given
-			if (request.profiletrigger)
+			if (request.pt)
 			{
-				idekey = request.profiletrigger;
+				pt = request.pt;
 			}
 
 			// Execute the requested command
 			if (request.cmd == "getStatus")
 			{
-				newStatus = exposed.getStatus(idekey);
+				newStatus = exposed.getStatus(idekey, tt, pt);
 			}
 			else if (request.cmd == "toggleStatus")
 			{
-				newStatus = exposed.toggleStatus(idekey);
+				newStatus = exposed.toggleStatus(idekey, tt, pt);
 			}
 			else if (request.cmd == "setStatus")
 			{
-				newStatus = exposed.setStatus(request.status, idekey, tracetrigger, profiletrigger);
+				newStatus = exposed.setStatus(request.status, idekey, tt, pt);
 			}
 
 			// Respond with the current status
@@ -83,7 +81,7 @@ var xdebug = (function() {
 		},
 
 		// Get current state
-		getStatus : function(idekey)
+		getStatus : function(idekey, tt, pt)
 		{
 			var status = 0;
 
@@ -91,11 +89,11 @@ var xdebug = (function() {
 			{
 				status = 1;
 			}
-			else if (getCookie("XDEBUG_PROFILE") == idekey)
+			else if (getCookie("XDEBUG_PROFILE") == pt)
 			{
 				status = 2;
 			}
-			else if (getCookie("XDEBUG_TRACE") == idekey)
+			else if (getCookie("XDEBUG_TRACE") == tt)
 			{
 				status = 3;
 			}
@@ -104,14 +102,14 @@ var xdebug = (function() {
 		},
 
 		// Toggle to the next state
-		toggleStatus : function(idekey)
+		toggleStatus : function(idekey, tt, pt)
 		{
-			var nextStatus = (exposed.getStatus(idekey) + 1) % 4;
-			return exposed.setStatus(nextStatus, idekey);
+			var nextStatus = (exposed.getStatus(idekey, tt, pt) + 1) % 4;
+			return exposed.setStatus(nextStatus, idekey, tt, pt);
 		},
 
 		// Set the state
-		setStatus : function(status, idekey, tracetrigger, profiletrigger)
+		setStatus : function(status, idekey, tt, pt)
 		{
 			if (status == 1)
 			{
@@ -124,23 +122,16 @@ var xdebug = (function() {
 			{
 				// Set profiling on
 				deleteCookie("XDEBUG_SESSION");
-				setCookie("XDEBUG_PROFILE", idekey, 24);
-				if (profiletrigger)
-				{
-					setCookie("XDEBUG_PROFILE_ENABLE_TRIGGER_VALUE", profiletrigger, 24);
-				}
+				setCookie("XDEBUG_PROFILE", pt, 24);
 				deleteCookie("XDEBUG_TRACE");
+
 			}
 			else if (status == 3)
 			{
 				// Set tracing on
 				deleteCookie("XDEBUG_SESSION");
 				deleteCookie("XDEBUG_PROFILE");
-				setCookie("XDEBUG_TRACE", idekey, 24);
-				if (tracetrigger)
-				{
-					setCookie("XDEBUG_TRACE_ENABLE_TRIGGER_VALUE", tracetrigger, 24);
-				}
+				setCookie("XDEBUG_TRACE", tt, 24);
 			}
 			else
 			{
@@ -151,7 +142,7 @@ var xdebug = (function() {
 			}
 
 			// Return the new status
-			return exposed.getStatus(idekey);
+			return exposed.getStatus(idekey, tt, pt);
 		}
 	};
 

--- a/source/content.js
+++ b/source/content.js
@@ -44,12 +44,24 @@ var xdebug = (function() {
 		messageListener : function(request, sender, sendResponse)
 		{
 			var newStatus,
-				idekey = "XDEBUG_ECLIPSE";
+				idekey = "XDEBUG_ECLIPSE",
+				tracetrigger = null,
+				profiletrigger = null;
 
 			// Use the IDE key from the request, if any is given
 			if (request.idekey)
 			{
 				idekey = request.idekey;
+			}
+			// Use the trace trigger key from the request, if any is given
+			if (request.tracetrigger)
+			{
+				idekey = request.tracetrigger;
+			}
+			// Use the profile trigger key from the request, if any is given
+			if (request.profiletrigger)
+			{
+				idekey = request.profiletrigger;
 			}
 
 			// Execute the requested command
@@ -63,7 +75,7 @@ var xdebug = (function() {
 			}
 			else if (request.cmd == "setStatus")
 			{
-				newStatus = exposed.setStatus(request.status, idekey);
+				newStatus = exposed.setStatus(request.status, idekey, tracetrigger, profiletrigger);
 			}
 
 			// Respond with the current status
@@ -99,7 +111,7 @@ var xdebug = (function() {
 		},
 
 		// Set the state
-		setStatus : function(status, idekey)
+		setStatus : function(status, idekey, tracetrigger, profiletrigger)
 		{
 			if (status == 1)
 			{
@@ -113,6 +125,10 @@ var xdebug = (function() {
 				// Set profiling on
 				deleteCookie("XDEBUG_SESSION");
 				setCookie("XDEBUG_PROFILE", idekey, 24);
+				if (profiletrigger)
+				{
+					setCookie("XDEBUG_PROFILE_ENABLE_TRIGGER_VALUE", profiletrigger, 24);
+				}
 				deleteCookie("XDEBUG_TRACE");
 			}
 			else if (status == 3)
@@ -121,6 +137,10 @@ var xdebug = (function() {
 				deleteCookie("XDEBUG_SESSION");
 				deleteCookie("XDEBUG_PROFILE");
 				setCookie("XDEBUG_TRACE", idekey, 24);
+				if (tracetrigger)
+				{
+					setCookie("XDEBUG_TRACE_ENABLE_TRIGGER_VALUE", tracetrigger, 24);
+				}
 			}
 			else
 			{

--- a/source/manifest.json
+++ b/source/manifest.json
@@ -1,7 +1,7 @@
 {
-	"name": "Xdebug helper",
+	"name": "Xdebug helper - DEV",
 	"description": "Easy debugging, profiling and tracing extension for Xdebug",
-	"version": "1.4.3",
+	"version": "1.5",
 	"author": "Mathijs Kadijk",
 
 	"manifest_version": 2,

--- a/source/options.css
+++ b/source/options.css
@@ -97,7 +97,7 @@ button {
 	margin-right: -7px;
 }
 
-#hint {
+.hint {
 	font-size: 0.8em;
 	padding: 7px;
 	width: 190px;
@@ -106,7 +106,7 @@ button {
 	border-radius: 5px;
 }
 
-#hint img {
+.hint img {
 	vertical-align: bottom;
 }
 

--- a/source/options.css
+++ b/source/options.css
@@ -13,6 +13,12 @@ h1, h2, h3 {
 	margin-bottom: -5px;
 }
 
+h3 {
+	background-color: rgba(61, 167, 41, 0.48);
+	color: rgba(27, 54, 23, 0.99);
+	padding: 5px;
+}
+
 h1 {
 	margin: 0 0 -15px 0;
 }
@@ -35,6 +41,13 @@ a.txtlink {
 body {
 	background-color: #eee;
 	font-size: 0.95em;
+}
+
+button {
+	float: right;
+	margin: 5px;
+	font-size: 1.25em;
+	color: rgba(27, 54, 23, 0.99);
 }
 
 .contentTxt {
@@ -89,7 +102,7 @@ body {
 	padding: 7px;
 	width: 190px;
 	text-align: center;
-	background-color: #c8e8c3;
+	background-color: rgb(251, 242, 185);
 	border-radius: 5px;
 }
 

--- a/source/options.html
+++ b/source/options.html
@@ -27,7 +27,7 @@
 				<img class="inlineicon" alt="" src="images/clock.png" /> Profiling enabled<br />
 				<img class="inlineicon" alt="" src="images/script.png" /> Tracing enabled
 			</p>
-			<p id="hint"><img src="images/lightbulb.png" alt="Tip!" title="Tip!" /> Love hotkeys? Try Ctrl+Shift+X</p>
+			<p class="hint"><img src="images/lightbulb.png" alt="Tip!" title="Tip!" /> Love hotkeys? Try Ctrl+Shift+X</p>
 
 			<h3>IDE key</h3>
 			<p class="note">Select your IDE to use the default sessionkey or choose other to use a custom key.</p>
@@ -46,14 +46,14 @@
 			<p class="note">If your xdebug is configured with a unique trace trigger key,
 			set that value here.  This value is blank by default.</p>
 			<p>
-				<input type="text" id="tracetrigger">
+				<input type="text" id="tracetrigger" value="">
 			</p>
 
 			<h3>Profile Trigger Value</h3>
 			<p class="note">If your xdebug is configured with a unique profile trigger key,
 				set that value here.  This value is blank by default.</p>
 			<p>
-				<input type="text" id="profiletrigger">
+				<input type="text" id="profiletrigger" value="">
 			</p>
 
 			<h3>Domain filter</h3>
@@ -68,7 +68,7 @@
 			<p>
 				<button class="button" id="save-options">Save Changes</button>
 			</p>
-			<p id="hint"><img class="inlineicon" src="images/lightbulb.png" alt="Tip!" title="Tip!" /> <a href="http://wrepblog.tumblr.com/post/31720573340/xdebug-helper-for-chrome-how-to-use-the-domain-filter" target="_blank">Need help? Read our <span>blogpost</span>!</a></p>
+			<p class="hint"><img class="inlineicon" src="images/lightbulb.png" alt="Tip!" title="Tip!" /> <a href="http://wrepblog.tumblr.com/post/31720573340/xdebug-helper-for-chrome-how-to-use-the-domain-filter" target="_blank">Need help? Read our <span>blogpost</span>!</a></p>
 		</div>
 
 		<div id="footer">

--- a/source/options.html
+++ b/source/options.html
@@ -39,7 +39,21 @@
 					<option value="PHPSTORM">PhpStorm</option>
 					<option value="null">Other</option>
 				</select>
-				<span id="customkey"><input type="text" id="idekey" /> <a href="#" id="save-options"><img id="saveButton" src="images/disk.png" alt="Save" title="Save" /></a></span>
+				<span id="customkey"><input type="text" id="idekey" /> </span>
+			</p>
+
+			<h3>Trace Trigger Value</h3>
+			<p class="note">If your xdebug is configured with a unique trace trigger key,
+			set that value here.  This value is blank by default.</p>
+			<p>
+				<input type="text" id="tracetrigger">
+			</p>
+
+			<h3>Profile Trigger Value</h3>
+			<p class="note">If your xdebug is configured with a unique profile trigger key,
+				set that value here.  This value is blank by default.</p>
+			<p>
+				<input type="text" id="profiletrigger">
 			</p>
 
 			<h3>Domain filter</h3>
@@ -51,6 +65,9 @@
 				<a id='remove-site'><img id="removeButton" src="images/delete.png" alt="Remove selected" title="Remove selected" /></a>
 			</p>
 
+			<p>
+				<button class="button" id="save-options">Save Changes</button>
+			</p>
 			<p id="hint"><img class="inlineicon" src="images/lightbulb.png" alt="Tip!" title="Tip!" /> <a href="http://wrepblog.tumblr.com/post/31720573340/xdebug-helper-for-chrome-how-to-use-the-domain-filter" target="_blank">Need help? Read our <span>blogpost</span>!</a></p>
 		</div>
 

--- a/source/options.js
+++ b/source/options.js
@@ -1,8 +1,11 @@
 function save_options()
 {
-	input = document.getElementById("idekey");
-	idekey = input.value;
+	key = document.getElementById("idekey");
+	idekey = key.value;
 	localStorage["xdebugIdeKey"] = idekey;
+
+	localStorage["xdebugTraceTrigger"] = document.getElementById("tracetrigger").valueOf();
+	localStorage["xdebugProfileTrigger"] = document.getElementById("profiletrigger").valueOf();
 
 	siteBox = document.getElementById("siteBox");
 	sites = [];
@@ -15,6 +18,7 @@ function save_options()
 
 function restore_options()
 {
+	// Restore IDE Key
 	idekey = localStorage["xdebugIdeKey"];
 
 	if (!idekey)
@@ -33,6 +37,23 @@ function restore_options()
 	}
 	$('#idekey').val(idekey);
 
+	// Restore Trace Triggers
+	var tt = localStorage["xdebugTraceTrigger"]
+	if (tt)	{
+		$("#tracetrigger").val(tt);
+	} else {
+		$("#tracetrigger").val();
+	}
+
+	// Restore Profile Triggers
+	var pt = localStorage["xdebugProfileTrigger"]
+	if (pt)	{
+		$("#profiletrigger").val(pt);
+	} else {
+		$("#profiletrigger").val();
+	}
+
+	// Restore Sites
 	sites = localStorage["sites"];
 	if (sites)
 	{

--- a/source/options.js
+++ b/source/options.js
@@ -1,11 +1,8 @@
 function save_options()
 {
-	key = document.getElementById("idekey");
-	idekey = key.value;
-	localStorage["xdebugIdeKey"] = idekey;
-
-	localStorage["xdebugTraceTrigger"] = document.getElementById("tracetrigger").valueOf();
-	localStorage["xdebugProfileTrigger"] = document.getElementById("profiletrigger").valueOf();
+	localStorage["xdebugIdeKey"] = document.getElementById("idekey").value;
+	localStorage["xdebugTraceTrigger"] = document.getElementById("tracetrigger").value;
+	localStorage["xdebugProfileTrigger"] = document.getElementById("profiletrigger").value;
 
 	siteBox = document.getElementById("siteBox");
 	sites = [];
@@ -38,19 +35,19 @@ function restore_options()
 	$('#idekey').val(idekey);
 
 	// Restore Trace Triggers
-	var tt = localStorage["xdebugTraceTrigger"]
-	if (tt)	{
+	var tt = localStorage["xdebugTraceTrigger"];
+	if (tt !== null)	{
 		$("#tracetrigger").val(tt);
 	} else {
-		$("#tracetrigger").val();
+		$("#tracetrigger").val(null);
 	}
 
 	// Restore Profile Triggers
-	var pt = localStorage["xdebugProfileTrigger"]
-	if (pt)	{
+	var pt = localStorage["xdebugProfileTrigger"];
+	if (pt !== null)	{
 		$("#profiletrigger").val(pt);
 	} else {
-		$("#profiletrigger").val();
+		$("#profiletrigger").val(null);
 	}
 
 	// Restore Sites

--- a/source/popup.js
+++ b/source/popup.js
@@ -1,10 +1,22 @@
 $(function() {
 	var ideKey = "XDEBUG_ECLIPSE";
+	var tt = ideKey;
+	var pt = ideKey;
 
 	// Check if localStorage is available and get the ideKey out of it if any
 	if (localStorage && localStorage["xdebugIdeKey"])
 	{
 		ideKey = localStorage["xdebugIdeKey"];
+	}
+
+	if (localStorage && localStorage["xdebugTraceTrigger"])
+	{
+		tt = localStorage["xdebugTraceTrigger"];
+	}
+
+	if (localStorage && localStorage["xdebugProfileTrigger"])
+	{
+		pt = localStorage["xdebugProfileTrigger"];
 	}
 
 	// Request the current state from the active tab
@@ -14,7 +26,9 @@ $(function() {
 				tabs[0].id,
 				{
 					cmd: "getStatus",
-					idekey: ideKey
+					idekey: ideKey,
+					tt: tt,
+					pt: pt
 				},
 				function(response)
 				{
@@ -36,7 +50,9 @@ $(function() {
 				{
 					cmd: "setStatus",
 					status: newStatus,
-					idekey: ideKey
+					idekey: ideKey,
+					tt : tt,
+					pt : pt
 				},
 				function(response)
 				{


### PR DESCRIPTION
I had a situation where I needed a trace trigger value and noticed that your extension did not support that feature yet.  So, I've added support for trace and profile trigger values into the code. 

The trigger value is passed as the trace or profile cookie value, replacing the idekey you were using. If the user does not set a value, it defaults to "xdebug_eclipse", which seemed an innocuous value.  

The config page got a bit full with the two extra boxes, so I modified the style a bit to keep it looking clean.  I ended up with a save button that gets hidden on shorter screens, so it may need some tweaking.

Let me know if you run into any issues.  I've been running it on my local box without any trouble but haven't had anyone else test it out.