### PR TITLE
Fixed saving trace and profiler keys

### DIFF
--- a/source/background.js
+++ b/source/background.js
@@ -62,19 +62,22 @@ chrome.commands.onCommand.addListener(function(command)
 		var profileTrigger = ideKey;
 
 		// Check if localStorage is available and get the settings out of it
-		if (localStorage && localStorage["xdebugIdeKey"])
+		if (localStorage)
 		{
-			ideKey = localStorage["xdebugIdeKey"];
-		}
+			if (localStorage["xdebugIdeKey"])
+			{
+				ideKey = localStorage["xdebugIdeKey"];
+			}
 
-		if (localStorage && localStorage["xdebugTraceTrigger"])
-		{
-			traceTrigger = localStorage["xdebugTraceTrigger"];
-		}
+			if (localStorage["xdebugTraceTrigger"])
+			{
+				traceTrigger = localStorage["xdebugTraceTrigger"];
+			}
 
-		if (localStorage && localStorage["xdebugProfileTrigger"])
-		{
-			profileTrigger = localStorage["xdebugProfileTrigger"];
+			if (localStorage["xdebugProfileTrigger"])
+			{
+				profileTrigger = localStorage["xdebugProfileTrigger"];
+			}
 		}
 
 		// Fetch the active tab

--- a/source/content.js
+++ b/source/content.js
@@ -45,8 +45,8 @@ var xdebug = (function() {
 		{
 			var newStatus,
 				idekey = "XDEBUG_ECLIPSE",
-				traceTrigger = null,
-				profileTrigger = null;
+				traceTrigger = idekey,
+				profileTrigger = idekey;
 
 			// Use the IDE key from the request, if any is given
 			if (request.idekey)

--- a/source/options.html
+++ b/source/options.html
@@ -40,7 +40,7 @@
 					<option value="null">Other</option>
 				</select>
 				<span id="customkey"><input type="text" id="idekey" /> </span>
-				<button class="button" class="save-button">Save</button>
+				<button class="save-button" class="save-button">Save</button>
 			</p>
 
 			<h3>Trace Trigger Value</h3>
@@ -48,7 +48,7 @@
 			set that value here.  This value is blank by default.</p>
 			<p>
 				<input type="text" id="tracetrigger" value="">
-				<button class="button" class="save-button">Save</button>
+				<button class="save-button" class="save-button">Save</button>
 			</p>
 
 			<h3>Profile Trigger Value</h3>
@@ -56,7 +56,7 @@
 				set that value here.  This value is blank by default.</p>
 			<p>
 				<input type="text" id="profiletrigger" value="">
-				<button class="button" class="save-button">Save</button>
+				<button class="save-button" class="save-button">Save</button>
 			</p>
 		</div>
 

--- a/source/popup.js
+++ b/source/popup.js
@@ -4,19 +4,22 @@ $(function() {
 	var profileTrigger = ideKey;
 
 	// Check if localStorage is available and get the ideKey out of it if any
-	if (localStorage && localStorage["xdebugIdeKey"])
+	if (localStorage)
 	{
-		ideKey = localStorage["xdebugIdeKey"];
-	}
+		if (localStorage["xdebugIdeKey"])
+		{
+			ideKey = localStorage["xdebugIdeKey"];
+		}
 
-	if (localStorage && localStorage["xdebugTraceTrigger"])
-	{
-		traceTrigger = localStorage["xdebugTraceTrigger"];
-	}
+		if (localStorage["xdebugTraceTrigger"])
+		{
+			traceTrigger = localStorage["xdebugTraceTrigger"];
+		}
 
-	if (localStorage && localStorage["xdebugProfileTrigger"])
-	{
-		profileTrigger = localStorage["xdebugProfileTrigger"];
+		if (localStorage["xdebugProfileTrigger"])
+		{
+			profileTrigger = localStorage["xdebugProfileTrigger"];
+		}
 	}
 
 	// Request the current state from the active tab


### PR DESCRIPTION
Currently saving trace and profiler keys is not possible because of the wrong selector in the options page.

I also made localstorage query expressions a bit more uniform across all files.