### PR TITLE
Describe hotkeys

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -5,6 +5,11 @@ Debugging, profiling and tracing PHP code with [Xdebug](http://xdebug.org/) is v
 Xdebug with cookies or adding POST/GET variables is way too hard. This extension will help you to enable/disable
 debugging, profiling and tracing of your PHP-code easily.
 
+Hotkeys
+-------
+Ctrl+Shift+X (Cmd+Shift+X on Mac) opens the popup.  
+Alt+Shift+X toggles the debugging state.
+
 How to install this extension?
 ------------------------------
 **Stable version:** Go to the [Google Chrome Web Store](https://chrome.google.com/webstore/detail/eadndfjplgieldjbigjakmdgkmoaaaoc)

--- a/source/options.html
+++ b/source/options.html
@@ -27,7 +27,7 @@
 				<img class="inlineicon" alt="" src="images/clock.png" /> Profiling enabled<br />
 				<img class="inlineicon" alt="" src="images/script.png" /> Tracing enabled
 			</p>
-			<p class="hint"><img src="images/lightbulb.png" alt="Tip!" title="Tip!" /> Love hotkeys? Try Ctrl+Shift+X</p>
+			<p class="hint"><img src="images/lightbulb.png" alt="Tip!" title="Tip!" /> Love hotkeys? Use Ctrl+Shift+X (Cmd+Shift+X on Mac) to open the popup, Alt+Shift+X to toggle the debugging state.</p>
 
 			<h3>IDE key</h3>
 			<p class="note">Select your IDE to use the default sessionkey or choose other to use a custom key.</p>


### PR DESCRIPTION
Initially I forked this repository to change the browser_action behavior: I wanted it to toggle the debugging behavior instead of opening the popup. But during the code examination I found that there is an undocumented hotkey for that!

It would save me some time if Alt+Shift+X was described in the readme and/or on the options page.

Can you please also add hotkeys description to the Crome extension page?

And thank you for the cool project!