### PR TITLE
Check status on every tab switch

### DIFF
--- a/source/background.js
+++ b/source/background.js
@@ -1,12 +1,5 @@
-chrome.tabs.onUpdated.addListener(function(tabId, changeInfo, tab)
+function fetchStatusAndUpdate(tabId)
 {
-	// We only react on a complete load of a http(s) page,
-	//  only then we're sure the content.js is loaded.
-	if (changeInfo.status !== "complete" || tab.url.indexOf("http") !== 0)
-	{
-		return;
-	}
-
 	// Prep some variables
 	var ideKey = "XDEBUG_ECLIPSE",
 		match = true,
@@ -53,6 +46,23 @@ chrome.tabs.onUpdated.addListener(function(tabId, changeInfo, tab)
 			updateIcon(response.status, tabId);
 		}
 	);
+}
+
+chrome.tabs.onActivated.addListener(function(info)
+{
+	fetchStatusAndUpdate(info.tabId);
+});
+
+chrome.tabs.onUpdated.addListener(function(tabId, changeInfo, tab)
+{
+	// We only react on a complete load of a http(s) page,
+	//  only then we're sure the content.js is loaded.
+	if (changeInfo.status !== "complete" || tab.url.indexOf("http") !== 0)
+	{
+		return;
+	}
+
+	fetchStatusAndUpdate(tabId);
 });
 
 chrome.commands.onCommand.addListener(function(command)


### PR DESCRIPTION
I don't understand the early return in `chrome.tabs.onUpdated`, because I always want to know the status. When you're loading a tab, you don't know it Xdebug is on. That's strange.

This PR doesn't fix that, because you probably have your reasons, but it does add a `chrome.tabs.onActivated` to status check for every tab switch. Currently, you can only see the actual status inside the popup, because the icon doesn't update after a tab switch.

I think the whole thing can be much simpler with [webRequest](https://developer.chrome.com/extensions/webRequest), but this is a start.