### PR TITLE
Add Atom as IDE option

### DIFF
--- a/source/options.html
+++ b/source/options.html
@@ -35,6 +35,7 @@
 			<p class="note">Select your IDE to use the default sessionkey or choose other to use a custom key.</p>
 			<p>
 				<select id="ide">
+					<option value="xdebug-atom">Atom + php-debug</option>
 					<option value="XDEBUG_ECLIPSE">Eclipse</option>
 					<option value="netbeans-xdebug">Netbeans</option>
 					<option value="macgdbp">MacGDBp</option>

--- a/source/options.js
+++ b/source/options.js
@@ -21,7 +21,7 @@
 			idekey = "XDEBUG_ECLIPSE";
 		}
 
-		if (idekey == "XDEBUG_ECLIPSE" || idekey == "netbeans-xdebug" || idekey == "macgdbp" || idekey == "PHPSTORM")
+		if (idekey == "XDEBUG_ECLIPSE" || idekey == "netbeans-xdebug" || idekey == "macgdbp" || idekey == "PHPSTORM" || idekey == "xdebug-atom" )
 		{
 			$("#ide").val(idekey);
 			$("#idekey").prop('disabled', true);


### PR DESCRIPTION
Fixes #90

Adds a new option `Atom + php-debug` with value `xdebug-atom` to the IDE select.

## Changes introduced by this PR

* Adds a new option with value `xdebug-atom` to the IDE `select` in `options.html`
* Adds a new comparison against the value `xdebug-atom` for the `idekey` var in `option.js`/`restore_options()`

## Screenshots

#### New option value:

![image](https://user-images.githubusercontent.com/746152/37176272-a4444214-22fa-11e8-9689-aca8f140e890.png)

#### Cookie being sent properly:

![image](https://user-images.githubusercontent.com/746152/37176329-d7288dca-22fa-11e8-93c0-b1fe6607da2e.png)

#### Select working correctly with new value 

![select](https://user-images.githubusercontent.com/746152/37176400-0ad3291e-22fb-11e8-8495-9407af04bc69.gif)


